### PR TITLE
Support for Grand Central M4

### DIFF
--- a/RGBmatrixPanel.cpp
+++ b/RGBmatrixPanel.cpp
@@ -106,7 +106,11 @@ void RGBmatrixPanel::init(uint8_t rows, uint8_t a, uint8_t b, uint8_t c,
   ) {
 #if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_ESP32)
   // R1, G1, B1, R2, G2, B2 pins
-  static const uint8_t defaultrgbpins[] = { 2,3,4,5,6,7 };
+  #if defined(ADAFRUIT_GRAND_CENTRAL_M4)
+    static const uint8_t defaultrgbpins[] = { 32,33,34,35,36,37 };
+  #else
+   static const uint8_t defaultrgbpins[] = { 2,3,4,5,6,7 };
+  #endif
   memcpy(rgbpins, pinlist ? pinlist : defaultrgbpins, sizeof rgbpins);
 #if defined(ARDUINO_ARCH_SAMD)
   // All six RGB pins MUST be on the same PORT # as CLK


### PR DESCRIPTION
I've modified the library to get RGB Matrix to work with the Grand Central M4.

On line 109 I've changed :
static const uint8_t defaultrgbpins[] = { 2,3,4,5,6,7 };

By:
#if defined(ADAFRUIT_GRAND_CENTRAL_M4)
    static const uint8_t defaultrgbpins[] = { 32,33,34,35,36,37 };
  #else
   static const uint8_t defaultrgbpins[] = { 2,3,4,5,6,7 };
  #endif

Use pins :
32: R1
33: G1
34: B1
35: R2
36: G2
37: B2

23, 25,26 or 27 for the CLK

Demo:
https://youtu.be/fcOJrAZpxJc

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
